### PR TITLE
Add fix for token IAT

### DIFF
--- a/HealthAgentAPI/healthAgentAPI.js
+++ b/HealthAgentAPI/healthAgentAPI.js
@@ -12,7 +12,7 @@ const jwtSecret = process.argv[4];
 const BASE_URL = "https://us.healthbot.microsoft.com/";
 const jwtToken = jwt.sign({
     tenantName: tenantName,
-    iat: Math.floor(Date.now()  / 1000)
+    iat: Math.floor(Date.now()  / 1000) - 30  // Subtract 30 seconds to avoid sync issues with API and token start time
   }, jwtSecret);
 
 if (action === "post_scenarios") {

--- a/HealthAgentAPI/package.json
+++ b/HealthAgentAPI/package.json
@@ -4,9 +4,9 @@
   "description": "",
   "main": "healthAgentAPI.js",
   "dependencies": {
+    "jsonwebtoken": "^8.0.1",
     "request": "^2.82.0",
-    "request-promise": "^4.2.2",
-    "jsonwebtoken": "^8.0.1"
+    "request-promise": "^4.2.2"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Resolves issue #2 

Subtract 30 seconds from generated IAT time to avoid token time falling in the future compared to API server time.